### PR TITLE
missing block subject #47

### DIFF
--- a/Resources/views/Contact/email.txt.twig
+++ b/Resources/views/Contact/email.txt.twig
@@ -11,6 +11,9 @@ file that was distributed with this source code.
 
 {% trans_default_domain 'MremiContactBundle' %}
 
+{% block subject %}
+{% endblock %}
+
 {% block body_text %}
 {% autoescape false %}
 {{ 'mremi_contact.email_message_txt'|trans({


### PR DESCRIPTION
Hello,

I have this error after submitting the form

> 

> Block "subject" on template "MremiContactBundle:Contact:email.txt.twig" does not exist in "MremiContactBundle:Contact:email.txt.twig".